### PR TITLE
[FE] Header 수정( 프로필사진, 로그인, 로그아웃)

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -4,20 +4,25 @@ import sublogo from '../../assets/sublogo.png';
 import styled from 'styled-components';
 import { FaInbox, FaStackExchange } from 'react-icons/fa';
 import { BiSearch } from 'react-icons/bi';
+import { useNavigate } from 'react-router-dom';
 import { BsFillTrophyFill, BsFillQuestionCircleFill } from 'react-icons/bs';
 
 const Header: React.FC = () => {
   //나중에 로컬스토리지에서 받아오는 것으로 수정.
   //const memberId = localStorage.getItem('memberId');
+  const navigate = useNavigate();
   const memberId = 1;
   const handleImgError = (e) => {
     e.target.src = 'https://i.ibb.co/gwgngJy/cutecat.jpg';
     //프로필이미지가 없을때 기본 프로필!
   };
+  const moveToMain = () => {
+    navigate('/');
+  };
   return (
     <StyledWrapper>
       <HeaderContainer>
-        <LogoWrapper>
+        <LogoWrapper onClick={moveToMain}>
           <img src={logo} className="header-logo" />
           <img src={sublogo} className="header-sublogo"></img>
         </LogoWrapper>


### PR DESCRIPTION
(로그인한 경우 && 프로필 이미지 있을 때)
<img width="900" alt="스크린샷 2023-06-25 오전 11 57 32" src="https://github.com/codestates-seb/seb44_pre_014/assets/70904075/2e6d477e-fd47-41d3-a9f0-2b0897d7c397">
(로그인 한 경우가 아닐때)
<img width="900" alt="스크린샷 2023-06-25 오전 11 59 19" src="https://github.com/codestates-seb/seb44_pre_014/assets/70904075/2f30bd7e-f287-4aa9-b0d6-1850f08b29d2">

- 로그인 상황에 따른 프로필 이미지 display( 로그인했을때 프로필이미지가 없다면 기본 프로필(cat)로 표시됩니다.)(https://ibb.co/VDBKBTV)
- login , logout 버튼 상황(로그인한 경우, 로그인하지 않은 경우)에 맞게 display 